### PR TITLE
⬆️ chore(CI): update gh-actions deployment deps

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,25 +30,31 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Set up Node
         uses: actions/setup-node@v3
         with:
           node-version: 'lts/*'
           cache: 'npm'
+
       - name: Install dependencies
         run: npm ci --omit=dev
+
       - name: Build
         run: npm run build:prod
+
       - name: Copy index.html to 404.html
         # see https://stackoverflow.com/a/76148302
         run: cp ./dist/index.html ./dist/404.html
+
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
+
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
-          # Upload dist repository
           path: './dist'
+
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
this bumps:
-  actions/configure-pages: v3 -> v5
- actions/upload-pages-artifact: v2 -> v3
- actions/deploy-pages: v2 -> v4

Resources:
- https://github.blog/changelog/2024-03-25-github-pages-with-custom-github-actions-workflows-are-now-generally-available/
- https://github.com/actions/starter-workflows/blob/a00915e13e33549ccc21799315b83d80afa2757c/pages/gatsby.yml#L59-L61
- https://github.com/actions/starter-workflows/blob/a00915e13e33549ccc21799315b83d80afa2757c/pages/gatsby.yml#L82-L97